### PR TITLE
Fix login URL and update tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = call_quality_hub.settings
+DJANGO_SETTINGS_MODULE = qualityhub.settings
 python_files = tests.py test_*.py *_tests.py
 addopts = -v --reuse-db 

--- a/templates/base.html
+++ b/templates/base.html
@@ -421,7 +421,7 @@
                             </div>
                         </div>
                     {% else %}
-                        <a href="{% url 'accounts:login' %}" class="px-6 py-3 bg-gradient-primary text-white rounded-xl font-semibold hover-scale hover:shadow-lg transition-all duration-300">
+                        <a href="{% url 'login' %}" class="px-6 py-3 bg-gradient-primary text-white rounded-xl font-semibold hover-scale hover:shadow-lg transition-all duration-300">
                             Giriş Yap
                         </a>
                     {% endif %}
@@ -610,7 +610,7 @@
                         </p>
                         
                         <div class="flex flex-col sm:flex-row gap-4 justify-center items-center">
-                            <a href="{% url 'accounts:login' %}" class="px-8 py-4 bg-gradient-primary text-white rounded-2xl font-semibold hover-scale hover:shadow-2xl transition-all duration-300 flex items-center space-x-3">
+                            <a href="{% url 'login' %}" class="px-8 py-4 bg-gradient-primary text-white rounded-2xl font-semibold hover-scale hover:shadow-2xl transition-all duration-300 flex items-center space-x-3">
                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1"></path>
                                 </svg>

--- a/users/urls.py
+++ b/users/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
     # Authentication URLs
     path(
         "login/",
-        auth_views.LoginView.as_view(template_name="users/login.html"),
+        auth_views.LoginView.as_view(template_name="accounts/login.html"),
         name="login",
     ),
     path("logout/", auth_views.LogoutView.as_view(), name="logout"),


### PR DESCRIPTION
## Summary
- fix login view template path
- update links in base template
- correct Django settings path for tests
- add missing `__init__` for users module

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68403a29f778832383892ba79eaf3501